### PR TITLE
Fix warnings when compiling with Elixir 1.11+

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Aes256.Mixfile do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :crypto]
     ]
   end
 


### PR DESCRIPTION
Elixir 1.11.0 (https://github.com/elixir-lang/elixir/releases/) adds "Compiler checks: application boundaries" that result in warning like the following when compiling:

warning: :crypto.block_decrypt/4 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
...

Added :crypto to extra_applications in order to resolve them.
